### PR TITLE
Fix User model to_json url value

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -241,7 +241,7 @@ class User(UserMixin, db.Model):
 
     def to_json(self):
         json_user = {
-            'url': url_for('api.get_post', id=self.id, _external=True),
+            'url': url_for('api.get_user', id=self.id, _external=True),
             'username': self.username,
             'member_since': self.member_since,
             'last_seen': self.last_seen,
@@ -271,6 +271,7 @@ class User(UserMixin, db.Model):
 
 
 class AnonymousUser(AnonymousUserMixin):
+
     def can(self, permissions):
         return False
 

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -6,6 +6,7 @@ from app.models import User, AnonymousUser, Role, Permission, Follow
 
 
 class UserModelTestCase(unittest.TestCase):
+
     def setUp(self):
         self.app = create_app('testing')
         self.app_context = self.app.app_context()
@@ -187,3 +188,12 @@ class UserModelTestCase(unittest.TestCase):
         db.session.delete(u2)
         db.session.commit()
         self.assertTrue(Follow.query.count() == 1)
+
+    def test_to_json(self):
+        u = User(email='john@example.com', password='cat')
+        db.session.add(u)
+        db.session.commit()
+        json_user = u.to_json()
+        expected_keys = ['url', 'username', 'member_since', 'last_seen', 'posts', 'followed_posts', 'post_count']
+        self.assertEqual(sorted(json_user.keys()), sorted(expected_keys))
+        self.assertTrue('api/v1.0/users/' in json_user['url'])


### PR DESCRIPTION
The User model’s to_json() returned an object whose url value was for a
post whose id matched the user’s; this wasn’t the intended behavior, so
this commit changes the url value to be the intended resource for the
user.  Included is a test to check both the keys that should be present
in a user’s json representation as well as a check that the url
returned is for a user.
